### PR TITLE
add --cron and --cron-schedule flag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 __pycache__
 .ccls-cache
+
+.idea/

--- a/tipocket-ctl/tpctl/argo.py
+++ b/tipocket-ctl/tpctl/argo.py
@@ -163,7 +163,9 @@ class ArgoCronCase(ArgoCase):
 
     def gen_workflow(self):
         workflow = super().gen_workflow()
+        workflow['metadata']['generateName'] += 'cron-'
         workflow['kind'] = 'CronWorkflow'
+        workflow['spec'] = {'workflowSpec': workflow['spec']}
         for k, v in self.cron_params.items():
             workflow['spec'][k] = v
         return workflow

--- a/tipocket-ctl/tpctl/argo.py
+++ b/tipocket-ctl/tpctl/argo.py
@@ -14,6 +14,9 @@ class ArgoCase:
         self.case = case
         self.image = image
 
+        # to name argo workflow and namespace
+        self.deploy_id = f'tpctl-{self.case.meta.name}-{self.feature}'
+
         # resources info
         self.tidb_cluster = tidb_cluster
 
@@ -41,7 +44,7 @@ class ArgoCase:
         main_steps.append([self.gen_case_step()])
         workflow = {
             'metadata': {
-                'generateName': f'tpctl-{self.case.meta.name}-{self.feature}-',
+                'generateName': self.deploy_id + '-',
                 'namespace': 'argo',
             },
             'spec': {
@@ -160,10 +163,10 @@ class ArgoCronCase(ArgoCase):
         super().__init__(feature, case, image, tidb_cluster,
                          notify, notify_users)
         self.cron_params = cron_params
+        self.deploy_id = f'tpctl-{self.case.meta.name}-{self.feature}-cron'
 
     def gen_workflow(self):
         workflow = super().gen_workflow()
-        workflow['metadata']['generateName'] += 'cron-'
         workflow['kind'] = 'CronWorkflow'
         workflow['spec'] = {'workflowSpec': workflow['spec']}
         for k, v in self.cron_params.items():

--- a/tipocket-ctl/tpctl/argo.py
+++ b/tipocket-ctl/tpctl/argo.py
@@ -8,14 +8,14 @@ from tpctl.yaml_dump_tidbcluster import dump
 
 class ArgoCase:
     def __init__(self, feature, case: CaseInstance, image, tidb_cluster,
-                 notify=False, notify_users=None):
+                 deploy_id="", notify=False, notify_users=None):
         # case metadata and build info
         self.feature = feature
         self.case = case
         self.image = image
 
         # to name argo workflow and namespace
-        self.deploy_id = f'tpctl-{self.case.meta.name}-{self.feature}'
+        self.deploy_id = deploy_id
 
         # resources info
         self.tidb_cluster = tidb_cluster
@@ -159,11 +159,10 @@ class ArgoCase:
 
 class ArgoCronCase(ArgoCase):
     def __init__(self, feature, case: CaseInstance, image, tidb_cluster,
-                 notify=False, notify_users=None, cron_params=None):
+                 deploy_id="", notify=False, notify_users=None, cron_params=None):
         super().__init__(feature, case, image, tidb_cluster,
-                         notify, notify_users)
+                         deploy_id, notify, notify_users)
         self.cron_params = cron_params
-        self.deploy_id = f'tpctl-{self.case.meta.name}-{self.feature}-cron'
 
     def gen_workflow(self):
         workflow = super().gen_workflow()

--- a/tipocket-ctl/tpctl/argo.py
+++ b/tipocket-ctl/tpctl/argo.py
@@ -83,6 +83,7 @@ class ArgoCase:
     def gen_notify_template(self, users):
         def encode(s):
             return base64.b64encode(bytes(s, 'utf-8')).decode('utf-8')
+
         encoded_cmd = encode(self.case.get_cmd())
         encoded_tidbcluster = encode(dump(self.tidb_cluster.to_json()))
         return {
@@ -151,3 +152,18 @@ class ArgoCase:
 
     def _get_case_template_name(self):
         return self.case.meta.name
+
+
+class ArgoCronCase(ArgoCase):
+    def __init__(self, feature, case: CaseInstance, image, tidb_cluster,
+                 notify=False, notify_users=None, cron_params=None):
+        super().__init__(feature, case, image, tidb_cluster,
+                         notify, notify_users)
+        self.cron_params = cron_params
+
+    def gen_workflow(self):
+        workflow = super().gen_workflow()
+        workflow['kind'] = 'CronWorkflow'
+        for k, v in self.cron_params.items():
+            workflow['spec'][k] = v
+        return workflow

--- a/tipocket-ctl/tpctl/deploy.py
+++ b/tipocket-ctl/tpctl/deploy.py
@@ -17,9 +17,11 @@ class Deploy:
         self._is_cron = params['cron'] is True
 
         if self._is_cron:
+            self.deploy_id = f'tpctl-{self.case.name}-{self.feature}-cron'
             self._argo_workflow_filepath = \
                 f'{env.dir_root}/{case.name}-{feature}-cron.yaml'
         else:
+            self.deploy_id = f'tpctl-{self.case.name}-{self.feature}'
             self._argo_workflow_filepath = \
                 f'{env.dir_root}/{case.name}-{feature}.yaml'
 
@@ -38,7 +40,7 @@ class Deploy:
         subscribers = self.params['subscriber'] or None
         if self._is_cron:
             argo_case = ArgoCronCase(self.feature, case_inst, self.image, tidb_cluster,
-                                     notify=True, notify_users=subscribers,
+                                     deploy_id=self.deploy_id, notify=True, notify_users=subscribers,
                                      cron_params={
                                          'schedule': self.params['cron_schedule'],
                                          'concurrencyPolicy': self.params['cron_concurrency_policy'],
@@ -47,10 +49,10 @@ class Deploy:
                                      })
         else:
             argo_case = ArgoCase(self.feature, case_inst, self.image, tidb_cluster,
-                                 notify=True, notify_users=subscribers)
+                                 deploy_id=self.deploy_id, notify=True, notify_users=subscribers)
         namespace = case_params['namespace']
         if not namespace:
-            case_params['namespace'] = argo_case.deploy_id
+            case_params['namespace'] = self.deploy_id
         return argo_case
 
     def get_howto_cmds(self):

--- a/tipocket-ctl/tpctl/deploy.py
+++ b/tipocket-ctl/tpctl/deploy.py
@@ -46,7 +46,8 @@ class Deploy:
                                 cron_params={
                                     'schedule': self.params['cron_schedule'],
                                     'concurrencyPolicy': self.params['cron_concurrency_policy'],
-                                    'startingDeadlineSeconds': self.params['cron_starting_deadline_seconds']
+                                    'startingDeadlineSeconds': self.params['cron_starting_deadline_seconds'],
+                                    'timezone': self.params['cron_timezone']
                                 })
         else:
             return ArgoCase(self.feature, case_inst, self.image, tidb_cluster,

--- a/tipocket-ctl/tpctl/deploy.py
+++ b/tipocket-ctl/tpctl/deploy.py
@@ -33,26 +33,25 @@ class Deploy:
 
     def generate_case(self):
         case_params = parse_params(self.params)
-        namespace = case_params['namespace']
-        if not namespace:
-            namespace = f'tpctl-{self.case.name}-{self.feature}'
-            case_params['namespace'] = namespace
         case_inst = CaseInstance(self.case, self.binary, case_params)
         tidb_cluster = get_tidb_cluster_spec_from_params(self.params)
         subscribers = self.params['subscriber'] or None
         if self._is_cron:
-            case_params['namespace'] += '-cron'
-            return ArgoCronCase(self.feature, case_inst, self.image, tidb_cluster,
-                                notify=True, notify_users=subscribers,
-                                cron_params={
-                                    'schedule': self.params['cron_schedule'],
-                                    'concurrencyPolicy': self.params['cron_concurrency_policy'],
-                                    'startingDeadlineSeconds': self.params['cron_starting_deadline_seconds'],
-                                    'timezone': self.params['cron_timezone']
-                                })
+            argo_case = ArgoCronCase(self.feature, case_inst, self.image, tidb_cluster,
+                                     notify=True, notify_users=subscribers,
+                                     cron_params={
+                                         'schedule': self.params['cron_schedule'],
+                                         'concurrencyPolicy': self.params['cron_concurrency_policy'],
+                                         'startingDeadlineSeconds': self.params['cron_starting_deadline_seconds'],
+                                         'timezone': self.params['cron_timezone']
+                                     })
         else:
-            return ArgoCase(self.feature, case_inst, self.image, tidb_cluster,
-                            notify=True, notify_users=subscribers)
+            argo_case = ArgoCase(self.feature, case_inst, self.image, tidb_cluster,
+                                 notify=True, notify_users=subscribers)
+        namespace = case_params['namespace']
+        if not namespace:
+            case_params['namespace'] = argo_case.deploy_id
+        return argo_case
 
     def get_howto_cmds(self):
         if self._is_cron:

--- a/tipocket-ctl/tpctl/deploy.py
+++ b/tipocket-ctl/tpctl/deploy.py
@@ -14,8 +14,9 @@ class Deploy:
         self.binary = binary
         self.image = image
         self.params = params
+        self._is_cron = params['cron'] is True
 
-        if params['cron']:
+        if self._is_cron:
             self._argo_workflow_filepath = \
                 f'{env.dir_root}/{case.name}-{feature}-cron.yaml'
         else:
@@ -39,7 +40,7 @@ class Deploy:
         case_inst = CaseInstance(self.case, self.binary, case_params)
         tidb_cluster = get_tidb_cluster_spec_from_params(self.params)
         subscribers = self.params['subscriber'] or None
-        if self.params['cron']:
+        if self._is_cron:
             case_params['namespace'] += '-cron'
             return ArgoCronCase(self.feature, case_inst, self.image, tidb_cluster,
                                 notify=True, notify_users=subscribers,
@@ -54,7 +55,7 @@ class Deploy:
                             notify=True, notify_users=subscribers)
 
     def get_howto_cmds(self):
-        if self.params['cron']:
+        if self._is_cron:
             return [
                 f'argo cron create {self._argo_workflow_filepath}'
             ]

--- a/tipocket-ctl/tpctl/params.py
+++ b/tipocket-ctl/tpctl/params.py
@@ -8,7 +8,7 @@ def parse_params(params):
     # convert parameters to the format that tipocket test case recognize
     case_params = {}
     for key, value in params.items():
-        if key in ['build_image', 'subscriber', 'feature', 'cron', 'cron_schedule']:
+        if key in ['build_image', 'subscriber', 'feature', 'cron', 'cron_schedule', 'cron_concurrency_policy', 'cron_starting_deadline_seconds']:
             continue
         # convert True/False to 'true/false'
         if key == 'purge':

--- a/tipocket-ctl/tpctl/params.py
+++ b/tipocket-ctl/tpctl/params.py
@@ -1,5 +1,16 @@
 from tpctl.tidb_cluster import ComponentName, ComponentSpec, TidbClusterSpec
 
+# Those options (Most are in prepare.COMMON_OPTIONS) won't be passed to tipocket case.
+IGNORE_OPTION_LIST = [
+    'build_image',
+    'subscriber',
+    'feature',
+    'cron',
+    'cron_schedule',
+    'cron_concurrency_policy',
+    'cron_starting_deadline_seconds',
+    'cron_timezone'
+]
 
 def parse_params(params):
     """
@@ -8,7 +19,7 @@ def parse_params(params):
     # convert parameters to the format that tipocket test case recognize
     case_params = {}
     for key, value in params.items():
-        if key in ['build_image', 'subscriber', 'feature', 'cron', 'cron_schedule', 'cron_concurrency_policy', 'cron_starting_deadline_seconds']:
+        if key in IGNORE_OPTION_LIST:
             continue
         # convert True/False to 'true/false'
         if key == 'purge':

--- a/tipocket-ctl/tpctl/params.py
+++ b/tipocket-ctl/tpctl/params.py
@@ -8,7 +8,7 @@ def parse_params(params):
     # convert parameters to the format that tipocket test case recognize
     case_params = {}
     for key, value in params.items():
-        if key in ['build_image', 'subscriber', 'feature']:
+        if key in ['build_image', 'subscriber', 'feature', 'cron', 'cron_schedule']:
             continue
         # convert True/False to 'true/false'
         if key == 'purge':

--- a/tipocket-ctl/tpctl/prepare.py
+++ b/tipocket-ctl/tpctl/prepare.py
@@ -28,6 +28,10 @@ COMMON_OPTIONS = (
     optgroup.group('Test case build options'),
     optgroup.option('--build-image/--no-build-image', default=False),
 
+    optgroup.group('Test case deploy options'),
+    optgroup.option('--cron', default=False),
+    optgroup.option('--cron-schedule', default='* * * * *'),
+
     optgroup.group('Test case common options'),
     optgroup.option('--client', default='5'),
     optgroup.option('--run-time', default='10m'),

--- a/tipocket-ctl/tpctl/prepare.py
+++ b/tipocket-ctl/tpctl/prepare.py
@@ -17,8 +17,11 @@ from tpctl.tidb_cluster import ComponentName
 # RESOURCES_DIR = 'tpctl-build/resources'
 COMPONENTS = ['tikv', 'tidb', 'pd']
 
+
+# Those options would be passed to tipocket case,
+# except those in params.IGNORE_OPTION_LIST.
 COMMON_OPTIONS = (
-    # NOTE: remember to update parse_params function when
+    # NOTE: remember to update params.IGNORE_OPTION_LIST when
     # a parameter is modified
 
     # people who receive notification
@@ -32,7 +35,7 @@ COMMON_OPTIONS = (
     optgroup.option('--cron/--not-cron', default=False),
     optgroup.option('--cron-schedule', default='30 17 * * *'),
     optgroup.option('--cron-timezone', default='Asia/Shanghai'),
-    optgroup.option('--cron-concurrency-policy', default='Allow'),
+    optgroup.option('--cron-concurrency-policy', default='Forbid'),
     optgroup.option('--cron-starting-deadline-seconds', default=0),
 
     optgroup.group('Test case common options'),
@@ -66,6 +69,7 @@ COMMON_OPTIONS = (
     optgroup.option('--loki-username', default=''),  # loki
     optgroup.option('--loki-password', default=''),  # admin
 )
+
 
 
 def testcase_common_options(func):
@@ -179,8 +183,7 @@ def rawkv_linearizability(**params):
 
 @prepare.command()
 @testcase_common_options
-@testcase('hello', 'hello',
-          ['@chenweiwen'])
+@testcase('hello', 'hello', ['@chenweiwen'])
 def hello(**params):
     """
     For debugging of tpctl itself.

--- a/tipocket-ctl/tpctl/prepare.py
+++ b/tipocket-ctl/tpctl/prepare.py
@@ -29,8 +29,10 @@ COMMON_OPTIONS = (
     optgroup.option('--build-image/--no-build-image', default=False),
 
     optgroup.group('Test case deploy options'),
-    optgroup.option('--cron', default=False),
-    optgroup.option('--cron-schedule', default='* * * * *'),
+    optgroup.option('--cron/--not-cron', default=False),
+    optgroup.option('--cron-schedule', default='30 17 * * *'),
+    optgroup.option('--cron-concurrency-policy', default='Replace'),
+    optgroup.option('--cron-starting-deadline-seconds', default='0'),
 
     optgroup.group('Test case common options'),
     optgroup.option('--client', default='5'),

--- a/tipocket-ctl/tpctl/prepare.py
+++ b/tipocket-ctl/tpctl/prepare.py
@@ -31,8 +31,9 @@ COMMON_OPTIONS = (
     optgroup.group('Test case deploy options'),
     optgroup.option('--cron/--not-cron', default=False),
     optgroup.option('--cron-schedule', default='30 17 * * *'),
-    optgroup.option('--cron-concurrency-policy', default='Replace'),
-    optgroup.option('--cron-starting-deadline-seconds', default='0'),
+    optgroup.option('--cron-timezone', default='Asia/Shanghai'),
+    optgroup.option('--cron-concurrency-policy', default='Allow'),
+    optgroup.option('--cron-starting-deadline-seconds', default=0),
 
     optgroup.group('Test case common options'),
     optgroup.option('--client', default='5'),
@@ -173,4 +174,14 @@ def gc_in_compaction_filter(**params):
 def rawkv_linearizability(**params):
     """
     rawkv linearizability
+    """
+
+
+@prepare.command()
+@testcase_common_options
+@testcase('hello', 'hello',
+          ['@chenweiwen'])
+def hello(**params):
+    """
+    For debugging of tpctl itself.
     """


### PR DESCRIPTION
Do minimum change to the original logic.

Other cron flags could be added like that.

ref: https://argoproj.github.io/argo/cron-workflows/

Usage:
```bash
 tpctl prepare rawkv-linearizability ... {Other flags} ... --cron --cron-schedule="* * * * *"
```

Generated workflow file like that:
```
kind: CronWorkflow
metadata:
  generateName: {Name}
  namespace: argo
spec:
  entrypoint: main
  onExit: on-exit
  schedule: '* * * * *'

...

```