### PR TITLE
`tpctl debug` command to generate debug commands in .env

### DIFF
--- a/tipocket-ctl/setup.py
+++ b/tipocket-ctl/setup.py
@@ -2,7 +2,6 @@
 
 from setuptools import setup
 
-
 setup(
     name='tpctl',
     version='0.1.dev0',
@@ -13,7 +12,8 @@ setup(
         'tpctl',
     ],
     package_data={
-        '': ['data/*']
+        '': ['data/*'],
+        '': ['scripts/env_raw.sh']
     },
     python_requires=">=3.6",
     url='https://github.com/cosven/tidb-testing/casectl',

--- a/tipocket-ctl/tpctl/__main__.py
+++ b/tipocket-ctl/tpctl/__main__.py
@@ -1,9 +1,11 @@
 from tpctl.app import cli
+from tpctl.debug import debug
 from tpctl.prepare import prepare
 
 
 def main():
     cli.add_command(prepare)
+    cli.add_command(debug)
     cli()
 
 

--- a/tipocket-ctl/tpctl/debug.py
+++ b/tipocket-ctl/tpctl/debug.py
@@ -1,4 +1,5 @@
 import inspect
+import pathlib
 
 import click
 
@@ -8,128 +9,43 @@ generate debug environment into .env file.
     Run `source .env` to get commands.
 
 \b
-You can find argument {deploy-id} and {cluster-namespace} in slack notification:
+You can find argument {deploy-id} in slack notification. eg:
 ============ Slack Notification ======================
 argo workflow
 tpctl-hello-test-tpctl-q948q
 ^^^ {DEPLOY ID} ^^^^^^^^^^^^
-...
-cmd
-/bin/hello ... -namespace="tpctl-hello-test-tpctl" ...
-               ^^^ {CLUSTER NAMESPACE} ^^^^^^^^^^^^^^^^^^
 =======================================================
 """
 
 
-def generate_script(deploy_id, cluster_namespace):
+def generate_script(deploy_id):
     variables = inspect.cleandoc("""
     DEPLOY_ID={}
-    CLUSTER_NAMESPACE={}
-    """.format(deploy_id, cluster_namespace))
+    """.format(deploy_id))
 
-    functions = inspect.cleandoc("""
-    # WARNING: All commands connect to `tidb` container of tidb pods by default.
-    # 	   As tidb pod has two containers
-    OUTPUT_DIR=output
-    CASE_POD_ID=$(argo get -n argo $DEPLOY_ID -o json | jq -r '.status.nodes[] | select(.type == "Pod" and .templateName != "notify") | .id')
-
-    echo "available commands:"
-    echo "- t_log_case"
-    echo "- t_ls_pod"
-    echo "- t_log_pod {pod-name}"
-    echo "- t_ssh_pod {pod-name}"
-    echo ""
-    echo "logs are stored in ./$OUTPUT_DIR/"
-
-    mkdir -p $OUTPUT_DIR
-
-    function is_name_tidb {
-        if [[ "$1" =~ .+-tidb-[0-9]+$ ]]; then
-            return 0
-        else
-            return 1
-        fi
-    }
-
-    function output_filepath {
-        echo "$OUTPUT_DIR/$1"
-    }
-
-    function get_argo_steps {
-        sed -n '/STEP */,$p' <(argo get -n argo $DEPLOY_ID)
-    }
-
-    function t_log_case {
-        OP=$(output_filepath log_case)
-        kubectl logs --namespace argo -c main $CASE_POD_ID > $OP
-        echo "log stored in $OP"
-    }
-
-    function t_ls_pod {
-        kubectl -n $CLUSTER_NAMESPACE get pods
-    }
-
-    function t_log_pod {
-        if [ "$1" == "" ]; then
-            echo "{pod-name} not set"
-            echo "Usage: t_log_pod {pod-name}"
-            return 1
-        fi
-
-        OP=$(output_filepath $1)
-        if [[ $(is_name_tidb $1) -eq 0 ]]; then
-            kubectl logs --namespace $CLUSTER_NAMESPACE $1 -c tidb > $OP
-        else
-            kubectl logs --namespace $CLUSTER_NAMESPACE $1 > $OP
-        fi
-        echo "log stored in $OP"
-    }
-
-    function t_ssh_pod {
-        if [ "$1" == "" ]; then
-            echo "{pod-name} not set"
-            echo "Usage: t_ssh_pod {pod-name}"
-            return 1
-        fi
-
-        if [[ $(is_name_tidb $1) -eq 0 ]]; then
-            kubectl -n $CLUSTER_NAMESPACE exec --stdin --tty $1 -c tidb -- /bin/sh
-        else
-            kubectl -n $CLUSTER_NAMESPACE exec --stdin --tty $1 -- /bin/sh
-        fi
-    }
-
-    """)
+    with open(pathlib.Path(__file__).parent.absolute() / './scripts/env_raw.sh', 'rt') as f:
+        functions = ''.join(f.readlines())
     return variables + '\n' + functions
 
 
 def print_debug_help():
-    click.echo('generate .env in current directory')
-    click.echo('Run:')
-    click.secho('source .env', fg='green')
-    click.echo('to get debug commands.')
+    click.echo(
+        'Generate .env in current directory\n' +
+        'Run to get debug commands:\n' +
+        click.style('source .env', fg='green')
+    )
 
 
 @click.command(help=HELP_STRING)
-@click.option('--deploy-id', help='id of test argo workflow')
-@click.option('--cluster-namespace', help='namespace of cluster running our test')
+@click.argument('deploy-id')
 def debug(**params):
     """
     Dependency: argo and kubectl are installed and properly configured in current machine.
     """
     deploy_id = params['deploy_id']
-    cluster_namespace = params['cluster_namespace']
-
-    if deploy_id is None or cluster_namespace is None:
-        click.echo('No deploy-id or cluster-namespace specified')
-        click.echo('Refer to slack notification')
-        click.echo('Or run:')
-        click.secho('tpctl debug --help', fg='green')
-        return
 
     with open(".env", 'wt') as f:
         f.write(generate_script(
-            deploy_id=deploy_id,
-            cluster_namespace=cluster_namespace
+            deploy_id=deploy_id
         ))
     print_debug_help()

--- a/tipocket-ctl/tpctl/debug.py
+++ b/tipocket-ctl/tpctl/debug.py
@@ -5,17 +5,7 @@ import click
 HELP_STRING = """
 generate debug environment into .env file.
 
-run:
-
-source .env
-
-\b
-Those shell commands are available in .env
-- case_log
-- ls_cluster_pods
-- cluster_pod_log {pod-id} [type]
-- ssh_cluster_pod {pod-id}
-- grafana 
+    Run `source .env` to get commands.
 
 \b
 You can find argument {deploy-id} and {cluster-namespace} in slack notification:

--- a/tipocket-ctl/tpctl/debug.py
+++ b/tipocket-ctl/tpctl/debug.py
@@ -106,7 +106,7 @@ def generate_script(deploy_id, cluster_namespace):
 def print_debug_help():
     click.echo('generate .env in current directory')
     click.echo('Run:')
-    click.secho('     source .env', fg='green')
+    click.secho('source .env', fg='green')
     click.echo('to get debug commands.')
 
 
@@ -117,9 +117,19 @@ def debug(**params):
     """
     Dependency: argo and kubectl are installed and properly configured in current machine.
     """
+    deploy_id = params['deploy_id']
+    cluster_namespace = params['cluster_namespace']
+
+    if deploy_id is None or cluster_namespace is None:
+        click.echo('No deploy-id or cluster-namespace specified')
+        click.echo('Refer to slack notification')
+        click.echo('Or run:')
+        click.secho('tpctl debug --help', fg='green')
+        return
+
     with open(".env", 'wt') as f:
         f.write(generate_script(
-            deploy_id=params['deploy_id'],
-            cluster_namespace=params['cluster_namespace'],
+            deploy_id=deploy_id,
+            cluster_namespace=cluster_namespace
         ))
     print_debug_help()

--- a/tipocket-ctl/tpctl/debug.py
+++ b/tipocket-ctl/tpctl/debug.py
@@ -1,0 +1,135 @@
+import inspect
+
+import click
+
+HELP_STRING = """
+generate debug environment into .env file.
+
+run:
+
+source .env
+
+\b
+Those shell commands are available in .env
+- case_log
+- ls_cluster_pods
+- cluster_pod_log {pod-id} [type]
+- ssh_cluster_pod {pod-id}
+- grafana 
+
+\b
+You can find argument {deploy-id} and {cluster-namespace} in slack notification:
+============ Slack Notification ======================
+argo workflow
+tpctl-hello-test-tpctl-q948q
+^^^ {DEPLOY ID} ^^^^^^^^^^^^
+...
+cmd
+/bin/hello ... -namespace="tpctl-hello-test-tpctl" ...
+               ^^^ {CLUSTER NAMESPACE} ^^^^^^^^^^^^^^^^^^
+=======================================================
+"""
+
+
+def generate_script(deploy_id, cluster_namespace):
+    variables = inspect.cleandoc("""
+    DEPLOY_ID={}
+    CLUSTER_NAMESPACE={}
+    """.format(deploy_id, cluster_namespace))
+
+    functions = inspect.cleandoc("""
+    # WARNING: All commands connect to `tidb` container of tidb pods by default.
+    # 	   As tidb pod has two containers
+    OUTPUT_DIR=output
+    CASE_POD_ID=$(argo get -n argo $DEPLOY_ID -o json | jq -r '.status.nodes[] | select(.type == "Pod" and .templateName != "notify") | .id')
+
+    echo "available commands:"
+    echo "- t_log_case"
+    echo "- t_ls_pod"
+    echo "- t_log_pod {pod-name}"
+    echo "- t_ssh_pod {pod-name}"
+    echo ""
+    echo "logs are stored in ./$OUTPUT_DIR/"
+
+    mkdir -p $OUTPUT_DIR
+
+    function is_name_tidb {
+        if [[ "$1" =~ .+-tidb-[0-9]+$ ]]; then
+            return 0
+        else
+            return 1
+        fi
+    }
+
+    function output_filepath {
+        echo "$OUTPUT_DIR/$1"
+    }
+
+    function get_argo_steps {
+        sed -n '/STEP */,$p' <(argo get -n argo $DEPLOY_ID)
+    }
+
+    function t_log_case {
+        OP=$(output_filepath log_case)
+        kubectl logs --namespace argo -c main $CASE_POD_ID > $OP
+        echo "log stored in $OP"
+    }
+
+    function t_ls_pod {
+        kubectl -n $CLUSTER_NAMESPACE get pods
+    }
+
+    function t_log_pod {
+        if [ "$1" == "" ]; then
+            echo "{pod-name} not set"
+            echo "Usage: t_log_pod {pod-name}"
+            return 1
+        fi
+
+        OP=$(output_filepath $1)
+        if [[ $(is_name_tidb $1) -eq 0 ]]; then
+            kubectl logs --namespace $CLUSTER_NAMESPACE $1 -c tidb > $OP
+        else
+            kubectl logs --namespace $CLUSTER_NAMESPACE $1 > $OP
+        fi
+        echo "log stored in $OP"
+    }
+
+    function t_ssh_pod {
+        if [ "$1" == "" ]; then
+            echo "{pod-name} not set"
+            echo "Usage: t_ssh_pod {pod-name}"
+            return 1
+        fi
+
+        if [[ $(is_name_tidb $1) -eq 0 ]]; then
+            kubectl -n $CLUSTER_NAMESPACE exec --stdin --tty $1 -c tidb -- /bin/sh
+        else
+            kubectl -n $CLUSTER_NAMESPACE exec --stdin --tty $1 -- /bin/sh
+        fi
+    }
+
+    """)
+    return variables + '\n' + functions
+
+
+def print_debug_help():
+    click.echo('generate .env in current directory')
+    click.echo('Run:')
+    click.secho('     source .env', fg='green')
+    click.echo('to get debug commands.')
+
+
+@click.command(help=HELP_STRING)
+@click.option('--deploy-id', help='id of test argo workflow')
+@click.option('--cluster-namespace', help='namespace of cluster running our test')
+def debug(**params):
+    """
+    Dependency: argo and kubectl are installed and properly configured in current machine.
+    """
+    with open(".env", 'wt') as f:
+        f.write(generate_script(
+            deploy_id=params['deploy_id'],
+            cluster_namespace=params['cluster_namespace'],
+        ))
+    print_debug_help()

--- a/tipocket-ctl/tpctl/debug.py
+++ b/tipocket-ctl/tpctl/debug.py
@@ -37,10 +37,7 @@ class DebugToolBox:
             f.write(self.script())
 
     def script(self):
-        variables = inspect.cleandoc("""
-        DEPLOY_ID={}
-        """.format(self.deploy_id))
-
+        variables = f'DEPLOY_ID={self.deploy_id}'
         with open(pathlib.Path(__file__).parent.absolute() / './scripts/env_raw.sh', 'rt') as f:
             functions = ''.join(f.readlines())
         return variables + '\n' + functions

--- a/tipocket-ctl/tpctl/scripts/env_raw.sh
+++ b/tipocket-ctl/tpctl/scripts/env_raw.sh
@@ -1,0 +1,72 @@
+# WARNING: All commands connect to `tidb` container of tidb pods by default.
+# 	   As tidb pod has two containers
+OUTPUT_DIR=output
+CASE_POD_ID=$(argo get -n argo $DEPLOY_ID -o json | jq -r '.status.nodes[] | select(.type == "Pod" and .templateName != "notify") | .id')
+CLUSTER_NAMESPACE=$(argo get -n argo $DEPLOY_ID -o json | jq -r '.spec.templates[-1].container.command[2]' | grep -oP '\-namespace=".*?"' | grep -o '".*"' | sed -e 's/^"//' -e 's/"$//')
+
+echo "available commands:"
+echo "- t_log_case"
+echo "- t_ls_pod"
+echo "- t_log_pod {pod-name}"
+echo "- t_ssh_pod {pod-name}"
+echo ""
+echo "logs are stored in ./$OUTPUT_DIR/"
+
+mkdir -p $OUTPUT_DIR
+
+function is_name_tidb {
+	if [[ "$1" =~ .+-tidb-[0-9]+$ ]]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+function output_filepath {
+	echo "$OUTPUT_DIR/$1"
+}
+
+function get_argo_steps {
+	sed -n '/STEP */,$p' <(argo get -n argo $DEPLOY_ID)
+}
+
+function t_log_case {
+	OP=$(output_filepath log_case)
+	kubectl logs --namespace argo -c main $CASE_POD_ID > $OP
+	echo "log stored in $OP"
+}
+
+function t_ls_pod {
+	kubectl -n $CLUSTER_NAMESPACE get pods
+}
+
+function t_log_pod {
+	if [ "$1" == "" ]; then
+		echo "{pod-name} not set"
+		echo "Usage: t_log_pod {pod-name}"
+		return 1
+	fi
+
+	OP=$(output_filepath $1)
+	if is_name_tidb "$1"; then
+		kubectl logs --namespace $CLUSTER_NAMESPACE $1 -c tidb > $OP
+	else
+		kubectl logs --namespace $CLUSTER_NAMESPACE $1 > $OP
+	fi
+	echo "log stored in $OP"
+}
+
+function t_ssh_pod {
+	if [ "$1" == "" ]; then
+		echo "{pod-name} not set"
+		echo "Usage: t_ssh_pod {pod-name}"
+		return 1
+	fi
+
+	if is_name_tidb "$1"; then
+		kubectl -n $CLUSTER_NAMESPACE exec --stdin --tty $1 -c tidb -- /bin/sh
+	else
+		kubectl -n $CLUSTER_NAMESPACE exec --stdin --tty $1 -- /bin/sh
+	fi
+}
+

--- a/tipocket-ctl/tpctl/scripts/env_raw.sh
+++ b/tipocket-ctl/tpctl/scripts/env_raw.sh
@@ -1,8 +1,13 @@
 # WARNING: All commands connect to `tidb` container of tidb pods by default.
 # 	   As tidb pod has two containers
 OUTPUT_DIR=output
-CASE_POD_ID=$(argo get -n argo $DEPLOY_ID -o json | jq -r '.status.nodes[] | select(.type == "Pod" and .templateName != "notify") | .id')
-CLUSTER_NAMESPACE=$(argo get -n argo $DEPLOY_ID -o json | jq -r '.spec.templates[-1].container.command[2]' | grep -oP '\-namespace=".*?"' | grep -o '".*"' | sed -e 's/^"//' -e 's/"$//')
+CASE_POD_ID=$(argo get -n argo $DEPLOY_ID -o json \
+              | jq -r '.status.nodes[] | select(.type == "Pod" and .templateName != "notify") | .id')
+CLUSTER_NAMESPACE=$(argo get -n argo $DEPLOY_ID -o json \
+                    | jq -r '.spec.templates[-1].container.command[2]' \
+                    | grep -oP '\-namespace=".*?"' \
+                    | grep -o '".*"' \
+                    | sed -e 's/^"//' -e 's/"$//')
 
 echo "available commands:"
 echo "- t_log_case"


### PR DESCRIPTION
## Example
```bash
$ tpctl debug --deploy-id tpctl-hello-test-tpctl-q948q --cluster-namespace tpctl-hello-test-tpctl-cron
generate .env in current directory
Run:
     source .env
to get debug commands.

$ source .env
available commands:
- t_log_case
- t_ls_pod
- t_log_pod {pod-name}
- t_ssh_pod {pod-name}

logs are stored in ./output/

$ t_ls_pod 
NAME                                                     READY   STATUS    RESTARTS   AGE
tpctl-hello-test-tpctl-cron-discovery-7ffd749cb4-zzk9x   1/1     Running   0          4d2h
tpctl-hello-test-tpctl-cron-monitor-6c54965968-gj26w     3/3     Running   0          4d2h
tpctl-hello-test-tpctl-cron-pd-0                         1/1     Running   0          4d2h
tpctl-hello-test-tpctl-cron-tidb-0                       2/2     Running   0          4d2h
tpctl-hello-test-tpctl-cron-tikv-0                       1/1     Running   0          4d2h
tpctl-hello-test-tpctl-cron-tikv-1                       1/1     Running   0          4d2h
tpctl-hello-test-tpctl-cron-tikv-2                       1/1     Running   0          4d2h
tpctl-hello-test-tpctl-cron-tikv-3                       1/1     Running   0          4d2h
tpctl-hello-test-tpctl-cron-tikv-4                       1/1     Running   0          4d2h
```