### PR TITLE
add --case-namespace flag to support non-tpctl deployed workflow

### DIFF
--- a/tipocket-ctl/tpctl/debug.py
+++ b/tipocket-ctl/tpctl/debug.py
@@ -25,8 +25,9 @@ class DebugToolBox:
     Use it to generate debug/ dir with commands in debug/.env
     """
 
-    def __init__(self, deploy_id, debug_parent="/tmp/"):
+    def __init__(self, deploy_id, case_namespace, debug_parent="/tmp/"):
         self.deploy_id = deploy_id
+        self.case_namespace = case_namespace
         self.debug_parent = pathlib.Path(debug_parent)
         self.debug_dir = pathlib.Path(debug_parent) / deploy_id
 
@@ -37,7 +38,7 @@ class DebugToolBox:
             f.write(self.script())
 
     def script(self):
-        variables = f'DEPLOY_ID={self.deploy_id}'
+        variables = f'DEPLOY_ID={self.deploy_id}\nCASE_NAMESPACE={self.case_namespace}'
         with open(pathlib.Path(__file__).parent.absolute() / './scripts/env_raw.sh', 'rt') as f:
             functions = ''.join(f.readlines())
         return variables + '\n' + functions
@@ -53,10 +54,14 @@ class DebugToolBox:
 
 @click.command(help=HELP_STRING)
 @click.argument('deploy-id')
+@click.option('--case-namespace', default='argo', help='Namespace of tipocket case itself. Default is `argo`.')
 def debug(**params):
     """
     Dependency: argo and kubectl are installed and properly configured in current machine.
     """
-    toolbox = DebugToolBox(params['deploy_id'])
+    toolbox = DebugToolBox(
+        deploy_id=params['deploy_id'],
+        case_namespace=params['case_namespace']
+    )
     toolbox.generate_all()
     toolbox.print_help()

--- a/tipocket-ctl/tpctl/scripts/env_raw.sh
+++ b/tipocket-ctl/tpctl/scripts/env_raw.sh
@@ -1,9 +1,9 @@
 # WARNING: All commands connect to `tidb` container of tidb pods by default.
 # 	   As tidb pod has two containers
 OUTPUT_DIR=output
-CASE_POD_ID=$(argo get -n argo $DEPLOY_ID -o json \
+CASE_POD_ID=$(argo get -n $CASE_NAMESPACE $DEPLOY_ID -o json \
               | jq -r '.status.nodes[] | select(.type == "Pod" and .templateName != "notify") | .id')
-CLUSTER_NAMESPACE=$(argo get -n argo $DEPLOY_ID -o json \
+CLUSTER_NAMESPACE=$(argo get -n $CASE_NAMESPACE $DEPLOY_ID -o json \
                     | jq -r '.spec.templates[-1].container.command[2]' \
                     | grep -oP '\-namespace=".*?"' \
                     | grep -o '".*"' \
@@ -32,12 +32,12 @@ function output_filepath {
 }
 
 function get_argo_steps {
-	sed -n '/STEP */,$p' <(argo get -n argo $DEPLOY_ID)
+	sed -n '/STEP */,$p' <(argo get -n $CASE_NAMESPACE $DEPLOY_ID)
 }
 
 function t_log_case {
 	OP=$(output_filepath log_case)
-	kubectl logs --namespace argo -c main $CASE_POD_ID > $OP
+	kubectl logs --namespace $CASE_NAMESPACE -c main $CASE_POD_ID > $OP
 	echo "log stored in $OP"
 }
 


### PR DESCRIPTION
Add a option to specify namespace of tipocket argo workflow case.

Default value is `argo`, to keep backward compatibility.

Usage:

```bash
# tpctl debug tpctl-hello-test-tpctl-q948q --case-namespace=MYNAMESPACE
```