### PR TITLE
Add command to display grafana port.

### DIFF
--- a/tipocket-ctl/tpctl/scripts/env_raw.sh
+++ b/tipocket-ctl/tpctl/scripts/env_raw.sh
@@ -9,13 +9,27 @@ CLUSTER_NAMESPACE=$(argo get -n argo $DEPLOY_ID -o json \
                     | grep -o '".*"' \
                     | sed -e 's/^"//' -e 's/"$//')
 
+function t_get_grafana_port {
+	grafana_port=$(kubectl -n $CLUSTER_NAMESPACE get svc -o json \
+		       | jq -r '.items[].spec.ports[]
+			        | select(.name == "http-grafana")
+				| .nodePort')
+	if [ "$grafana_port" == "" ]; then
+		echo "Grafana is not ready yet, please run t_get_grafana_port later."
+	else
+		echo "Grafana is on port $grafana_port, username and password are both admin."
+	fi
+}
+
 echo "available commands:"
 echo "- t_log_case"
 echo "- t_ls_pod"
 echo "- t_log_pod {pod-name}"
 echo "- t_ssh_pod {pod-name}"
+echo "- t_get_grafana_port"
 echo ""
 echo "logs are stored in ./$OUTPUT_DIR/"
+t_get_grafana_port # Print grafana port.
 
 mkdir -p $OUTPUT_DIR
 

--- a/tipocket-ctl/tpctl/scripts/env_raw.sh
+++ b/tipocket-ctl/tpctl/scripts/env_raw.sh
@@ -9,15 +9,20 @@ CLUSTER_NAMESPACE=$(argo get -n argo $DEPLOY_ID -o json \
                     | grep -o '".*"' \
                     | sed -e 's/^"//' -e 's/"$//')
 
-function t_get_grafana_port {
+function get_grafana_port {
 	grafana_port=$(kubectl -n $CLUSTER_NAMESPACE get svc -o json \
 		       | jq -r '.items[].spec.ports[]
 			        | select(.name == "http-grafana")
 				| .nodePort')
+}
+
+function t_get_grafana_addr {
+	grafana_port=$(get_grafana_port)
+	host_ip=$(hostname)
 	if [ "$grafana_port" == "" ]; then
-		echo "Grafana is not ready yet, please run t_get_grafana_port later."
+		echo "Grafana is not ready yet, please run t_get_grafana_addr later."
 	else
-		echo "Grafana is on port $grafana_port, username and password are both admin."
+		echo "Grafana is on $host_ip:$grafana_port, username and password are both admin."
 	fi
 }
 
@@ -26,10 +31,11 @@ echo "- t_log_case"
 echo "- t_ls_pod"
 echo "- t_log_pod {pod-name}"
 echo "- t_ssh_pod {pod-name}"
-echo "- t_get_grafana_port"
+echo "- t_get_grafana_addr"
 echo ""
 echo "logs are stored in ./$OUTPUT_DIR/"
-t_get_grafana_port # Print grafana port.
+t_get_grafana_addr # Print grafana port.
+
 
 mkdir -p $OUTPUT_DIR
 


### PR DESCRIPTION
Just a slight change in `scripts/env_raw.sh`.

Changed the reminder message to:
```bash
[root@172.16.4.67 tpctl-ledger-universal-4bsbs]# source .env 
available commands:
- t_log_case
- t_ls_pod
- t_log_pod {pod-name}
- t_ssh_pod {pod-name}
- t_get_grafana_port

logs are stored in ./output/
Grafana is on port 31170, username and password are both admin.
```

We could also call `t_get_grafana_port` explicitly:
```bash
[root@172.16.4.67 tpctl-ledger-universal-4bsbs]# get_grafana_port 
Grafana is on port 31170, username and password are both admin.
```