### PR TITLE
Fix t-get-grafana-addr

### DIFF
--- a/tipocket-ctl/tpctl/scripts/env_raw.sh
+++ b/tipocket-ctl/tpctl/scripts/env_raw.sh
@@ -10,7 +10,7 @@ CLUSTER_NAMESPACE=$(argo get -n argo $DEPLOY_ID -o json \
                     | sed -e 's/^"//' -e 's/"$//')
 
 function get_grafana_port {
-	grafana_port=$(kubectl -n $CLUSTER_NAMESPACE get svc -o json \
+	echo $(kubectl -n $CLUSTER_NAMESPACE get svc -o json \
 		       | jq -r '.items[].spec.ports[]
 			        | select(.name == "http-grafana")
 				| .nodePort')

--- a/tipocket-ctl/tpctl/scripts/env_raw.sh
+++ b/tipocket-ctl/tpctl/scripts/env_raw.sh
@@ -22,7 +22,7 @@ function t_get_grafana_addr {
 	if [ "$grafana_port" == "" ]; then
 		echo "Grafana is not ready yet, please run t_get_grafana_addr later."
 	else
-		echo "Grafana is on $host_ip:$grafana_port, username and password are both admin."
+		echo "Grafana is on http://$host_ip:$grafana_port, username and password are both admin."
 	fi
 }
 


### PR DESCRIPTION
Fixed t_get_grafana_addr command.
```
[root@172.16.4.67 tpctl-debug-210114]# source .env
available commands:
- t_log_case
- t_ls_pod
- t_log_pod {pod-name}
- t_ssh_pod {pod-name}
- t_get_grafana_addr

logs are stored in ./output/
Grafana is on http://172.16.4.67:32018, username and password are both admin.
```