### PR TITLE
Removed flags about loki, since tipocket has removed loki support.

### DIFF
--- a/tipocket-ctl/README.md
+++ b/tipocket-ctl/README.md
@@ -33,8 +33,8 @@ The command output looks like the following:
 ```
 Case name is resolve-lock
 Generating command for running case...
-/bin/resolve-lock -enable-green-gc=false -run-time="5m" -round="1" -client="5" -nemesis="" -purge="false" -delNS="false" -namespace="tpctl-resolve-lock-universal" -hub="docker.io" -repository="pingcap" -image-version="nightly" -tikv-image="" -tidb-image="" -pd-image="" -tikv-config="" -tidb-config="" -pd-config="" -tikv-replicas="5" -tidb-replicas="1" -pd-replicas="1" -storage-class="local-storage" -loki-addr="" -loki-username="" -loki-password=""
-Generating argo workflow tpctl-resolve-lock-universal.yaml...
+/bin/resolve-lock -enable-green-gc=false -run-time="5m" -round="1" -client="5" -wait-duration="10m" -nemesis="" -purge="true" -delNS="true" -namespace="tpctl-resolve-lock-universal" -hub="docker.io" -repository="pingcap" -image-version="nightly" -tikv-image="" -tidb-image="" -pd-image="" -tikv-config="" -tidb-config="" -pd-config="" -tikv-replicas="5" -tidb-replicas="1" -pd-replicas="1" -storage-class="local-storage"
+Generating argo workflow /tmp/tpctl-resolve-lock-universal.yaml...
 Run following commands to deploy the case
-argo submit tpctl-resolve-lock-universal.yaml
+argo submit /tmp/tpctl-resolve-lock-universal.yaml
 ```

--- a/tipocket-ctl/tpctl/deploy.py
+++ b/tipocket-ctl/tpctl/deploy.py
@@ -65,10 +65,6 @@ COMMON_OPTIONS = (
 
     optgroup.group('Test case logging options',
                    help='usually, you need not to change this'),
-    # set loki settings to empty since loki does not work well currently
-    optgroup.option('--loki-addr', default=''),  # http://gateway.loki.svc'
-    optgroup.option('--loki-username', default=''),  # loki
-    optgroup.option('--loki-password', default=''),  # admin
 )
 
 


### PR DESCRIPTION
`tipocket` has removed loki support in [log: remove loki client #373](https://github.com/pingcap/tipocket/pull/373).

The old `tpctl` would cause case raise such an error:
```bash
flag provided but not defined: -loki-addr
Usage of /bin/ttl:
  -abtest.concurrency int
        test concurrency, parallel session number (default 3)
```

So I removed flags about loki, `tpctl deploy` won't generate those flags anymore:

```bash
-loki-addr="" -loki-username="" -loki-password=""
```

It should be a safe change since [log: remove loki client #373](https://github.com/pingcap/tipocket/pull/373) has been merged.